### PR TITLE
Disappearing tabs bugfix

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneChatOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneChatOverlay.cs
@@ -208,39 +208,6 @@ namespace osu.Game.Tests.Visual.Online
             AddAssert("All channels closed", () => !channelManager.JoinedChannels.Any());
         }
 
-        [Test]
-        public void TestPMChannelDisplayBehavior()
-        {
-            // Adding PM channes
-            AddUntilStep("Join until dropdown has channels", () =>
-            {
-                if (visibleChannels.Count() < joinedChannels.Count())
-                    return true;
-
-                channelManager.JoinChannel(new Channel
-                {
-                    Name = $"Channel no. {joinedChannels.Count() + 11}",
-                    Type = ChannelType.PM
-                });
-
-                return false;
-            });
-
-            AddStep("Switch to last tab", () => clickDrawable(chatOverlay.TabMap[visibleChannels.Last()]));
-            AddAssert("Selected still visible", () => currentChannel == visibleChannels.Last());
-
-            // Selector reappearing after all channels closed
-            AddUntilStep("Close all channels", () =>
-            {
-                if (!joinedChannels.Any())
-                    return true;
-
-                chatOverlay.ChannelTabControl.RemoveChannel(joinedChannels.Last());
-                return false;
-            });
-            AddAssert("Selector is visible", () => chatOverlay.SelectionOverlayState == Visibility.Visible);
-        }
-
         private void pressChannelHotkey(int number)
         {
             var channelKey = Key.Number0 + number;

--- a/osu.Game.Tests/Visual/Online/TestSceneChatOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneChatOverlay.cs
@@ -208,6 +208,39 @@ namespace osu.Game.Tests.Visual.Online
             AddAssert("All channels closed", () => !channelManager.JoinedChannels.Any());
         }
 
+        [Test]
+        public void TestPMChannelDisplayBehavior()
+        {
+            // Adding PM channes
+            AddUntilStep("Join until dropdown has channels", () =>
+            {
+                if (visibleChannels.Count() < joinedChannels.Count())
+                    return true;
+
+                channelManager.JoinChannel(new Channel
+                {
+                    Name = $"Channel no. {joinedChannels.Count() + 11}",
+                    Type = ChannelType.PM
+                });
+
+                return false;
+            });
+
+            AddStep("Switch to last tab", () => clickDrawable(chatOverlay.TabMap[visibleChannels.Last()]));
+            AddAssert("Selected still visible", () => currentChannel == visibleChannels.Last());
+
+            // Selector reappearing after all channels closed
+            AddUntilStep("Close all channels", () =>
+            {
+                if (!joinedChannels.Any())
+                    return true;
+
+                chatOverlay.ChannelTabControl.RemoveChannel(joinedChannels.Last());
+                return false;
+            });
+            AddAssert("Selector is visible", () => chatOverlay.SelectionOverlayState == Visibility.Visible);
+        }
+
         private void pressChannelHotkey(int number)
         {
             var channelKey = Key.Number0 + number;

--- a/osu.Game/Overlays/Chat/Tabs/ChannelTabControl.cs
+++ b/osu.Game/Overlays/Chat/Tabs/ChannelTabControl.cs
@@ -101,7 +101,7 @@ namespace osu.Game.Overlays.Chat.Tabs
                 SelectTab(selectorTab);
 
             if (SelectedTab is PrivateChannelTabItem)
-                ((PrivateChannelTabItem)SelectedTab).TransitionToActive();
+                ((PrivateChannelTabItem)SelectedTab)?.TransitionToActive();
         }
 
         protected override void SelectTab(TabItem<Channel> tab)

--- a/osu.Game/Overlays/Chat/Tabs/ChannelTabControl.cs
+++ b/osu.Game/Overlays/Chat/Tabs/ChannelTabControl.cs
@@ -10,6 +10,7 @@ using System;
 using System.Linq;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Logging;
 
 namespace osu.Game.Overlays.Chat.Tabs
 {
@@ -38,20 +39,18 @@ namespace osu.Game.Overlays.Chat.Tabs
 
         private void updateTabs(TabItem<Channel> tab, bool visible)
         {
-            if (SelectedTab != tab) { return; }
-            if (tab == selectorTab) { return; }
-            if (visible) { return; }
+            if (visible || SelectedTab != tab)
+                return;
+
+            if (!(tab is PrivateChannelTabItem))
+                return;
 
             float newWidth = tab.Width - 10;
+
             if (newWidth > ChannelTabItem.MIN_TAB_SIZE)
-            {
                 tab.ResizeWidthTo(newWidth);
-            }
             else
-            {
-                tab.ResizeWidthTo(ChatOverlay.TAB_AREA_HEIGHT + 15);
-                ((ChannelTabItem)tab).HideCloseButton();
-            }
+                ((PrivateChannelTabItem)tab).TransitionToInactive();
         }
 
         protected override void AddTabItem(TabItem<Channel> item, bool addToDropdown = true)
@@ -98,6 +97,9 @@ namespace osu.Game.Overlays.Chat.Tabs
         public void RemoveChannel(Channel channel)
         {
             RemoveItem(channel);
+
+            if (SelectedTab is PrivateChannelTabItem)
+                ((PrivateChannelTabItem)SelectedTab).TransitionToActive();
 
             if (SelectedTab == null)
                 SelectTab(selectorTab);

--- a/osu.Game/Overlays/Chat/Tabs/ChannelTabControl.cs
+++ b/osu.Game/Overlays/Chat/Tabs/ChannelTabControl.cs
@@ -29,10 +29,29 @@ namespace osu.Game.Overlays.Chat.Tabs
 
             TabContainer.Spacing = new Vector2(-SHEAR_WIDTH, 0);
             TabContainer.Masking = false;
+            TabContainer.TabVisibilityChanged += updateTabs;
 
             AddTabItem(selectorTab = new ChannelSelectorTabItem());
 
             ChannelSelectorActive.BindTo(selectorTab.Active);
+        }
+
+        private void updateTabs(TabItem<Channel> tab, bool visible)
+        {
+            if (SelectedTab != tab) { return; }
+            if (tab == selectorTab) { return; }
+            if (visible) { return; }
+
+            float newWidth = tab.Width - 10;
+            if (newWidth > ChannelTabItem.MIN_TAB_SIZE)
+            {
+                tab.ResizeWidthTo(newWidth);
+            }
+            else
+            {
+                tab.ResizeWidthTo(ChatOverlay.TAB_AREA_HEIGHT + 15);
+                ((ChannelTabItem)tab).HideCloseButton();
+            }
         }
 
         protected override void AddTabItem(TabItem<Channel> item, bool addToDropdown = true)

--- a/osu.Game/Overlays/Chat/Tabs/ChannelTabControl.cs
+++ b/osu.Game/Overlays/Chat/Tabs/ChannelTabControl.cs
@@ -100,8 +100,8 @@ namespace osu.Game.Overlays.Chat.Tabs
             if (SelectedTab == null)
                 SelectTab(selectorTab);
 
-            if (SelectedTab is PrivateChannelTabItem)
-                ((PrivateChannelTabItem)SelectedTab)?.TransitionToActive();
+            if (SelectedTab is PrivateChannelTabItem PMSelectedTab)
+                PMSelectedTab.TransitionToActive();
         }
 
         protected override void SelectTab(TabItem<Channel> tab)

--- a/osu.Game/Overlays/Chat/Tabs/ChannelTabControl.cs
+++ b/osu.Game/Overlays/Chat/Tabs/ChannelTabControl.cs
@@ -100,8 +100,8 @@ namespace osu.Game.Overlays.Chat.Tabs
             if (SelectedTab == null)
                 SelectTab(selectorTab);
 
-            if (SelectedTab is PrivateChannelTabItem PMSelectedTab)
-                PMSelectedTab.TransitionToActive();
+            if (SelectedTab is PrivateChannelTabItem pMSelectedTab)
+                pMSelectedTab.TransitionToActive();
         }
 
         protected override void SelectTab(TabItem<Channel> tab)

--- a/osu.Game/Overlays/Chat/Tabs/ChannelTabControl.cs
+++ b/osu.Game/Overlays/Chat/Tabs/ChannelTabControl.cs
@@ -10,7 +10,6 @@ using System;
 using System.Linq;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Logging;
 
 namespace osu.Game.Overlays.Chat.Tabs
 {
@@ -98,11 +97,11 @@ namespace osu.Game.Overlays.Chat.Tabs
         {
             RemoveItem(channel);
 
-            if (SelectedTab is PrivateChannelTabItem)
-                ((PrivateChannelTabItem)SelectedTab).TransitionToActive();
-
             if (SelectedTab == null)
                 SelectTab(selectorTab);
+
+            if (SelectedTab is PrivateChannelTabItem)
+                ((PrivateChannelTabItem)SelectedTab).TransitionToActive();
         }
 
         protected override void SelectTab(TabItem<Channel> tab)

--- a/osu.Game/Overlays/Chat/Tabs/ChannelTabItem.cs
+++ b/osu.Game/Overlays/Chat/Tabs/ChannelTabItem.cs
@@ -28,8 +28,8 @@ namespace osu.Game.Overlays.Chat.Tabs
 
         public override bool IsRemovable => !Pinned;
 
-        protected const float close_button_padding = 20;
-        public const float MIN_TAB_SIZE = ChatOverlay.TAB_AREA_HEIGHT + TabCloseButton.BUTTON_SIZE + close_button_padding;
+        protected const float CLOSE_BUTTON_PADDING = 20;
+        public const float MIN_TAB_SIZE = ChatOverlay.TAB_AREA_HEIGHT + TabCloseButton.BUTTON_SIZE + CLOSE_BUTTON_PADDING;
 
         protected readonly SpriteText Text;
         protected readonly ClickableContainer CloseButton;
@@ -105,7 +105,7 @@ namespace osu.Game.Overlays.Chat.Tabs
                         CloseButton = new TabCloseButton
                         {
                             Alpha = 0,
-                            Margin = new MarginPadding { Right = close_button_padding },
+                            Margin = new MarginPadding { Right = CLOSE_BUTTON_PADDING },
                             Origin = Anchor.CentreRight,
                             Anchor = Anchor.CentreRight,
                             Action = delegate
@@ -127,11 +127,6 @@ namespace osu.Game.Overlays.Chat.Tabs
         protected virtual bool ShowCloseOnHover => true;
 
         protected virtual bool IsBoldWhenActive => true;
-
-        public void HideCloseButton()
-        {
-            CloseButton.FadeOut(200);
-        }
 
         protected override bool OnHover(HoverEvent e)
         {

--- a/osu.Game/Overlays/Chat/Tabs/ChannelTabItem.cs
+++ b/osu.Game/Overlays/Chat/Tabs/ChannelTabItem.cs
@@ -28,6 +28,9 @@ namespace osu.Game.Overlays.Chat.Tabs
 
         public override bool IsRemovable => !Pinned;
 
+        protected const float close_button_padding = 20;
+        public const float MIN_TAB_SIZE = ChatOverlay.TAB_AREA_HEIGHT + TabCloseButton.BUTTON_SIZE + close_button_padding;
+
         protected readonly SpriteText Text;
         protected readonly ClickableContainer CloseButton;
         private readonly Box box;
@@ -102,7 +105,7 @@ namespace osu.Game.Overlays.Chat.Tabs
                         CloseButton = new TabCloseButton
                         {
                             Alpha = 0,
-                            Margin = new MarginPadding { Right = 20 },
+                            Margin = new MarginPadding { Right = close_button_padding },
                             Origin = Anchor.CentreRight,
                             Anchor = Anchor.CentreRight,
                             Action = delegate
@@ -125,6 +128,11 @@ namespace osu.Game.Overlays.Chat.Tabs
 
         protected virtual bool IsBoldWhenActive => true;
 
+        public void HideCloseButton()
+        {
+            CloseButton.FadeOut(200);
+        }
+
         protected override bool OnHover(HoverEvent e)
         {
             if (IsRemovable && ShowCloseOnHover)
@@ -137,8 +145,11 @@ namespace osu.Game.Overlays.Chat.Tabs
 
         protected override void OnHoverLost(HoverLostEvent e)
         {
-            CloseButton.FadeOut(200, Easing.OutQuint);
-            updateState();
+            if (ShowCloseOnHover)
+            {
+                CloseButton.FadeOut(200, Easing.OutQuint);
+                updateState();
+            }
         }
 
         protected override void OnMouseUp(MouseUpEvent e)

--- a/osu.Game/Overlays/Chat/Tabs/PrivateChannelTabItem.cs
+++ b/osu.Game/Overlays/Chat/Tabs/PrivateChannelTabItem.cs
@@ -70,20 +70,28 @@ namespace osu.Game.Overlays.Chat.Tabs
 
         protected const float TAB_ACTIVE_WIDTH = 200;
 
+        public void TransitionToActive()
+        {
+            this.ResizeWidthTo(TAB_ACTIVE_WIDTH, TRANSITION_LENGTH, Easing.OutQuint);
+            CloseButton.FadeIn(TRANSITION_LENGTH, Easing.OutQuint);
+        }
+
+        public void TransitionToInactive()
+        {
+            this.ResizeWidthTo(ChatOverlay.TAB_AREA_HEIGHT + 10, TRANSITION_LENGTH, Easing.OutQuint);
+            CloseButton.FadeOut(TRANSITION_LENGTH, Easing.OutQuint);
+        }
+
         protected override void FadeActive()
         {
             base.FadeActive();
-
-            this.ResizeWidthTo(TAB_ACTIVE_WIDTH, TRANSITION_LENGTH, Easing.OutQuint);
-            CloseButton.FadeIn(TRANSITION_LENGTH, Easing.OutQuint);
+            TransitionToActive();
         }
 
         protected override void FadeInactive()
         {
             base.FadeInactive();
-
-            this.ResizeWidthTo(ChatOverlay.TAB_AREA_HEIGHT + 10, TRANSITION_LENGTH, Easing.OutQuint);
-            CloseButton.FadeOut(TRANSITION_LENGTH, Easing.OutQuint);
+            TransitionToInactive();
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game/Overlays/Chat/Tabs/PrivateChannelTabItem.cs
+++ b/osu.Game/Overlays/Chat/Tabs/PrivateChannelTabItem.cs
@@ -68,11 +68,13 @@ namespace osu.Game.Overlays.Chat.Tabs
 
         protected override bool ShowCloseOnHover => false;
 
+        protected const float TAB_ACTIVE_WIDTH = 200;
+
         protected override void FadeActive()
         {
             base.FadeActive();
 
-            this.ResizeWidthTo(200, TRANSITION_LENGTH, Easing.OutQuint);
+            this.ResizeWidthTo(TAB_ACTIVE_WIDTH, TRANSITION_LENGTH, Easing.OutQuint);
             CloseButton.FadeIn(TRANSITION_LENGTH, Easing.OutQuint);
         }
 

--- a/osu.Game/Overlays/Chat/Tabs/TabCloseButton.cs
+++ b/osu.Game/Overlays/Chat/Tabs/TabCloseButton.cs
@@ -14,9 +14,11 @@ namespace osu.Game.Overlays.Chat.Tabs
     {
         private readonly SpriteIcon icon;
 
+        public const float BUTTON_SIZE = 20;
+
         public TabCloseButton()
         {
-            Size = new Vector2(20);
+            Size = new Vector2(BUTTON_SIZE);
 
             Child = icon = new SpriteIcon
             {


### PR DESCRIPTION
This fix resizes rightmost PM tabs so they don't disappear off the right edge when opened as much as possible
- If resizing the tab will cause the tab to disappear, resizes the tab to a smaller size to keep it out of the dropdown
- If this resize causes the tab to become too small, resizes it to the minimum (inactive) size without the close button. 
- This potentially causes bugs if you close an earlier tab, this tab still won't expand to its maximum size -> **Fixed**
- **WIP**: Need to add test cases